### PR TITLE
don't process request if parameter doesn't match JSONP_CALLBACK_EXPRESSION

### DIFF
--- a/server.js
+++ b/server.js
@@ -368,6 +368,7 @@ Server.prototype = new function () {
         response.write("400: The parameter `callback` must match "
             + JSONP_CALLBACK_EXPRESSION + ".")
         response.end();
+        return;
       }
 
       var respond = function (status, headers, content) {


### PR DESCRIPTION
otherwise one could crash the server with ?callback=; (or similar)
